### PR TITLE
Keys to int8

### DIFF
--- a/services/lifthus-auth/api/auth/session.service.go
+++ b/services/lifthus-auth/api/auth/session.service.go
@@ -149,7 +149,7 @@ func (ac authApiController) HusSessionHandler(c echo.Context) error {
 	// from request body json, get sid string and uid string
 	scbd := common.HusSessionCheckBody{
 		Sid:           hscbParsed["sid"].(string),
-		Uid:           hscbParsed["uid"].(string),
+		Uid:           hscbParsed["uid"].(uint64),
 		Email:         hscbParsed["email"].(string),
 		EmailVerified: hscbParsed["email_verified"].(bool),
 		Name:          hscbParsed["name"].(string),
@@ -267,7 +267,7 @@ func (ac authApiController) SessionSignHandler(c echo.Context) error {
 	c.SetCookie(nstCookie)
 
 	// get user's Name from database using ls.UID
-	lsu, err := db.QueryUserByUID(c.Request().Context(), ac.dbClient, ls.UID.String())
+	lsu, err := db.QueryUserByUID(c.Request().Context(), ac.dbClient, *ls.UID)
 	if err != nil {
 		log.Println(err)
 		return c.String(http.StatusInternalServerError, err.Error())
@@ -275,10 +275,10 @@ func (ac authApiController) SessionSignHandler(c echo.Context) error {
 
 	// make struct with UID and Name
 	signResp := struct {
-		UID  string `json:"user_id"`
+		UID  uint64 `json:"user_id"`
 		Name string `json:"user_name"`
 	}{
-		UID:  ls.UID.String(),
+		UID:  *ls.UID,
 		Name: lsu.Name,
 	}
 	signRespJSON, err := json.Marshal(signResp)

--- a/services/lifthus-auth/common/dto.go
+++ b/services/lifthus-auth/common/dto.go
@@ -2,7 +2,7 @@ package common
 
 type HusSessionCheckBody struct {
 	Sid           string `json:"sid"`
-	Uid           uint64 `json:"uid"`
+	Uid           string `json:"uid"`
 	Email         string `json:"email"`
 	EmailVerified bool   `json:"email_verified"`
 	Name          string `json:"name"`

--- a/services/lifthus-auth/common/dto.go
+++ b/services/lifthus-auth/common/dto.go
@@ -2,7 +2,7 @@ package common
 
 type HusSessionCheckBody struct {
 	Sid           string `json:"sid"`
-	Uid           string `json:"uid"`
+	Uid           uint64 `json:"uid"`
 	Email         string `json:"email"`
 	EmailVerified bool   `json:"email_verified"`
 	Name          string `json:"name"`

--- a/services/lifthus-auth/common/lifthus/lifthus.go
+++ b/services/lifthus-auth/common/lifthus/lifthus.go
@@ -35,11 +35,22 @@ func InitLifthusVars(husenv string, _ *ent.Client) {
 		AuthURL = "https://auth.lifthus.com"
 		ApiURL = "https://api.lifthus.com"
 	case "development":
-		fallthrough
+		Host = "localhost:9100"
+		URL = "http://localhost:9100"
+		Origins = []string{"http://localhost:3000", "http://localhost:9000", "http://localhost:9200"}
+		CookieDomain = ""
+		AuthURL = "http://localhost:9091"
+		ApiURL = "http://localhost:9091"
 	case "native":
-		Host = "localhost:9091"
-		URL = "http://localhost:9091"
-		Origins = []string{"http://localhost:3000", "http://localhost:9090", "http://localhost:9091"}
+		Host = "localhost:9100"
+		URL = "http://localhost:9101"
+		Origins = []string{
+			"http://localhost:3000",
+			"http://localhost:9001",
+			"http://localhost:9002",
+			"http://localhost:9101",
+			"http://localhost:9102",
+		}
 		CookieDomain = ""
 		AuthURL = "http://localhost:9091"
 		ApiURL = "http://localhost:9091"

--- a/services/lifthus-auth/db/db.go
+++ b/services/lifthus-auth/db/db.go
@@ -30,7 +30,9 @@ func ConnectToLifthusAuth() (*ent.Client, error) {
 	}
 
 	// Running the auto migration tool.
-	if err := client.Schema.Create(context.Background()); err != nil {
+	if err := client.Schema.Create(
+		context.Background(),
+	); err != nil {
 		log.Print(" creating schema resources failed: %w", err)
 		return nil, err
 	}

--- a/services/lifthus-auth/db/user.go
+++ b/services/lifthus-auth/db/user.go
@@ -6,12 +6,17 @@ import (
 	"lifthus-auth/common"
 	"lifthus-auth/ent"
 	"lifthus-auth/ent/user"
+	"strconv"
 	"time"
 )
 
 func CreateNewLifthusUser(c context.Context, client *ent.Client, nu common.HusSessionCheckBody) (*ent.User, error) {
 	// create new lifthus user
-	lu := client.User.Create().SetID(nu.Uid).
+	nuUid, err := strconv.ParseUint(nu.Uid, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("!!parsing uid failed:%w", err)
+	}
+	lu := client.User.Create().SetID(nuUid).
 		SetEmail(nu.Email).
 		SetEmailVerified(nu.EmailVerified).
 		SetName(nu.Name).

--- a/services/lifthus-auth/db/user.go
+++ b/services/lifthus-auth/db/user.go
@@ -7,17 +7,11 @@ import (
 	"lifthus-auth/ent"
 	"lifthus-auth/ent/user"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 func CreateNewLifthusUser(c context.Context, client *ent.Client, nu common.HusSessionCheckBody) (*ent.User, error) {
-	uid_uuid, err := uuid.Parse(nu.Uid)
-	if err != nil {
-		return nil, fmt.Errorf("!!parsing uuid failed:%w", err)
-	}
 	// create new lifthus user
-	lu := client.User.Create().SetID(uid_uuid).
+	lu := client.User.Create().SetID(nu.Uid).
 		SetEmail(nu.Email).
 		SetEmailVerified(nu.EmailVerified).
 		SetName(nu.Name).
@@ -37,14 +31,50 @@ func CreateNewLifthusUser(c context.Context, client *ent.Client, nu common.HusSe
 	return nlu, nil
 }
 
-func QueryUserByUID(c context.Context, client *ent.Client, uid string) (*ent.User, error) {
-	uid_uuid, err := uuid.Parse(uid)
-	if err != nil {
-		return nil, fmt.Errorf("!!parsing uuid failed:%w", err)
-	}
-	u, err := client.User.Query().Where(user.ID(uid_uuid)).Only(context.Background())
+// UUID version
+// func CreateNewLifthusUser(c context.Context, client *ent.Client, nu common.HusSessionCheckBody) (*ent.User, error) {
+// 	uid_uuid, err := uuid.Parse(nu.Uid)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("!!parsing uuid failed:%w", err)
+// 	}
+// 	// create new lifthus user
+// 	lu := client.User.Create().SetID(uid_uuid).
+// 		SetEmail(nu.Email).
+// 		SetEmailVerified(nu.EmailVerified).
+// 		SetName(nu.Name).
+// 		SetGivenName(nu.GivenName).
+// 		SetFamilyName(nu.FamilyName)
+// 	if nu.Birthdate != "" {
+// 		t, err := time.Parse(time.RFC3339, nu.Birthdate)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("!!parsing birthdate failed:%w", err)
+// 		}
+// 		lu.SetBirthdate(t)
+// 	}
+// 	nlu, err := lu.Save(c)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("!!creating new lifthus userfailed:%w", err)
+// 	}
+// 	return nlu, nil
+// }
+
+func QueryUserByUID(c context.Context, client *ent.Client, uid uint64) (*ent.User, error) {
+	u, err := client.User.Query().Where(user.ID(uid)).Only(context.Background())
 	if err != nil && !ent.IsNotFound(err) {
 		return nil, fmt.Errorf("!!getting user by uid failed:%w", err)
 	}
 	return u, nil
 }
+
+// UUID version
+// func QueryUserByUID(c context.Context, client *ent.Client, uid string) (*ent.User, error) {
+// 	uid_uuid, err := uuid.Parse(uid)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("!!parsing uuid failed:%w", err)
+// 	}
+// 	u, err := client.User.Query().Where(user.ID(uid_uuid)).Only(context.Background())
+// 	if err != nil && !ent.IsNotFound(err) {
+// 		return nil, fmt.Errorf("!!getting user by uid failed:%w", err)
+// 	}
+// 	return u, nil
+// }

--- a/services/lifthus-auth/ent/client.go
+++ b/services/lifthus-auth/ent/client.go
@@ -508,7 +508,7 @@ func (c *UserClient) UpdateOne(u *User) *UserUpdateOne {
 }
 
 // UpdateOneID returns an update builder for the given id.
-func (c *UserClient) UpdateOneID(id uuid.UUID) *UserUpdateOne {
+func (c *UserClient) UpdateOneID(id uint64) *UserUpdateOne {
 	mutation := newUserMutation(c.config, OpUpdateOne, withUserID(id))
 	return &UserUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
@@ -525,7 +525,7 @@ func (c *UserClient) DeleteOne(u *User) *UserDeleteOne {
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.
-func (c *UserClient) DeleteOneID(id uuid.UUID) *UserDeleteOne {
+func (c *UserClient) DeleteOneID(id uint64) *UserDeleteOne {
 	builder := c.Delete().Where(user.ID(id))
 	builder.mutation.id = &id
 	builder.mutation.op = OpDeleteOne
@@ -542,12 +542,12 @@ func (c *UserClient) Query() *UserQuery {
 }
 
 // Get returns a User entity by its id.
-func (c *UserClient) Get(ctx context.Context, id uuid.UUID) (*User, error) {
+func (c *UserClient) Get(ctx context.Context, id uint64) (*User, error) {
 	return c.Query().Where(user.ID(id)).Only(ctx)
 }
 
 // GetX is like Get, but panics if an error occurs.
-func (c *UserClient) GetX(ctx context.Context, id uuid.UUID) *User {
+func (c *UserClient) GetX(ctx context.Context, id uint64) *User {
 	obj, err := c.Get(ctx, id)
 	if err != nil {
 		panic(err)

--- a/services/lifthus-auth/ent/migrate/schema.go
+++ b/services/lifthus-auth/ent/migrate/schema.go
@@ -24,7 +24,7 @@ var (
 		{Name: "connected_at", Type: field.TypeTime},
 		{Name: "signed_at", Type: field.TypeTime, Nullable: true},
 		{Name: "used", Type: field.TypeBool, Default: false},
-		{Name: "uid", Type: field.TypeUUID, Nullable: true},
+		{Name: "uid", Type: field.TypeUint64, Nullable: true},
 	}
 	// SessionsTable holds the schema information for the "sessions" table.
 	SessionsTable = &schema.Table{
@@ -42,7 +42,7 @@ var (
 	}
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
-		{Name: "id", Type: field.TypeUUID, Unique: true},
+		{Name: "id", Type: field.TypeUint64, Increment: true},
 		{Name: "registered", Type: field.TypeBool, Default: false},
 		{Name: "registered_at", Type: field.TypeTime, Nullable: true},
 		{Name: "username", Type: field.TypeString, Unique: true, Nullable: true},

--- a/services/lifthus-auth/ent/mutation.go
+++ b/services/lifthus-auth/ent/mutation.go
@@ -305,7 +305,7 @@ type SessionMutation struct {
 	signed_at     *time.Time
 	used          *bool
 	clearedFields map[string]struct{}
-	user          *uuid.UUID
+	user          *uint64
 	cleareduser   bool
 	done          bool
 	oldValue      func(context.Context) (*Session, error)
@@ -417,12 +417,12 @@ func (m *SessionMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 }
 
 // SetUID sets the "uid" field.
-func (m *SessionMutation) SetUID(u uuid.UUID) {
+func (m *SessionMutation) SetUID(u uint64) {
 	m.user = &u
 }
 
 // UID returns the value of the "uid" field in the mutation.
-func (m *SessionMutation) UID() (r uuid.UUID, exists bool) {
+func (m *SessionMutation) UID() (r uint64, exists bool) {
 	v := m.user
 	if v == nil {
 		return
@@ -433,7 +433,7 @@ func (m *SessionMutation) UID() (r uuid.UUID, exists bool) {
 // OldUID returns the old "uid" field's value of the Session entity.
 // If the Session object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SessionMutation) OldUID(ctx context.Context) (v *uuid.UUID, err error) {
+func (m *SessionMutation) OldUID(ctx context.Context) (v *uint64, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldUID is only allowed on UpdateOne operations")
 	}
@@ -587,7 +587,7 @@ func (m *SessionMutation) ResetUsed() {
 }
 
 // SetUserID sets the "user" edge to the User entity by id.
-func (m *SessionMutation) SetUserID(id uuid.UUID) {
+func (m *SessionMutation) SetUserID(id uint64) {
 	m.user = &id
 }
 
@@ -602,7 +602,7 @@ func (m *SessionMutation) UserCleared() bool {
 }
 
 // UserID returns the "user" edge ID in the mutation.
-func (m *SessionMutation) UserID() (id uuid.UUID, exists bool) {
+func (m *SessionMutation) UserID() (id uint64, exists bool) {
 	if m.user != nil {
 		return *m.user, true
 	}
@@ -612,7 +612,7 @@ func (m *SessionMutation) UserID() (id uuid.UUID, exists bool) {
 // UserIDs returns the "user" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
 // UserID instead. It exists only for internal usage by the builders.
-func (m *SessionMutation) UserIDs() (ids []uuid.UUID) {
+func (m *SessionMutation) UserIDs() (ids []uint64) {
 	if id := m.user; id != nil {
 		ids = append(ids, *id)
 	}
@@ -715,7 +715,7 @@ func (m *SessionMutation) OldField(ctx context.Context, name string) (ent.Value,
 func (m *SessionMutation) SetField(name string, value ent.Value) error {
 	switch name {
 	case session.FieldUID:
-		v, ok := value.(uuid.UUID)
+		v, ok := value.(uint64)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -749,13 +749,16 @@ func (m *SessionMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *SessionMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *SessionMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	}
 	return nil, false
 }
 
@@ -901,7 +904,7 @@ type UserMutation struct {
 	config
 	op                  Op
 	typ                 string
-	id                  *uuid.UUID
+	id                  *uint64
 	registered          *bool
 	registered_at       *time.Time
 	username            *string
@@ -943,7 +946,7 @@ func newUserMutation(c config, op Op, opts ...userOption) *UserMutation {
 }
 
 // withUserID sets the ID field of the mutation.
-func withUserID(id uuid.UUID) userOption {
+func withUserID(id uint64) userOption {
 	return func(m *UserMutation) {
 		var (
 			err   error
@@ -995,13 +998,13 @@ func (m UserMutation) Tx() (*Tx, error) {
 
 // SetID sets the value of the id field. Note that this
 // operation is only accepted on creation of User entities.
-func (m *UserMutation) SetID(id uuid.UUID) {
+func (m *UserMutation) SetID(id uint64) {
 	m.id = &id
 }
 
 // ID returns the ID value in the mutation. Note that the ID is only available
 // if it was provided to the builder or after it was returned from the database.
-func (m *UserMutation) ID() (id uuid.UUID, exists bool) {
+func (m *UserMutation) ID() (id uint64, exists bool) {
 	if m.id == nil {
 		return
 	}
@@ -1012,12 +1015,12 @@ func (m *UserMutation) ID() (id uuid.UUID, exists bool) {
 // That means, if the mutation is applied within a transaction with an isolation level such
 // as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
 // or updated by the mutation.
-func (m *UserMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
+func (m *UserMutation) IDs(ctx context.Context) ([]uint64, error) {
 	switch {
 	case m.op.Is(OpUpdateOne | OpDeleteOne):
 		id, exists := m.ID()
 		if exists {
-			return []uuid.UUID{id}, nil
+			return []uint64{id}, nil
 		}
 		fallthrough
 	case m.op.Is(OpUpdate | OpDelete):

--- a/services/lifthus-auth/ent/runtime.go
+++ b/services/lifthus-auth/ent/runtime.go
@@ -49,8 +49,4 @@ func init() {
 	user.DefaultUpdatedAt = userDescUpdatedAt.Default.(func() time.Time)
 	// user.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	user.UpdateDefaultUpdatedAt = userDescUpdatedAt.UpdateDefault.(func() time.Time)
-	// userDescID is the schema descriptor for id field.
-	userDescID := userFields[0].Descriptor()
-	// user.DefaultID holds the default value on creation for the id field.
-	user.DefaultID = userDescID.Default.(func() uuid.UUID)
 }

--- a/services/lifthus-auth/ent/schema/session.go
+++ b/services/lifthus-auth/ent/schema/session.go
@@ -18,7 +18,7 @@ type Session struct {
 func (Session) Fields() []ent.Field {
 	return []ent.Field{
 		field.UUID("id", uuid.UUID{}).StructTag(`json:"sid,omitempty"`).Default(uuid.New).Unique(), // sid
-		field.UUID("uid", uuid.UUID{}).Optional().Nillable(),
+		field.Uint64("uid").Optional().Nillable(),
 		field.Time("connected_at").Default(time.Now),                          // connected at
 		field.Time("signed_at").Optional().Nillable().UpdateDefault(time.Now), // signed at
 		field.Bool("used").Default(false),                                     // used to sign Lifthus session

--- a/services/lifthus-auth/ent/schema/user.go
+++ b/services/lifthus-auth/ent/schema/user.go
@@ -6,7 +6,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
-	"github.com/google/uuid"
 )
 
 // User holds the schema definition for the User entity.
@@ -17,7 +16,7 @@ type User struct {
 // Fields of the User.
 func (User) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("id", uuid.UUID{}).StructTag(`json:"uid,omitempty"`).Default(uuid.New).Unique(), // user id from Hus
+		field.Uint64("id").StructTag(`json:"uid,omitempty"`).Unique(), // user id from Hus
 
 		field.Bool("registered").Default(false),           // whether the hus user is registered to Lifthus
 		field.Time("registered_at").Optional().Nillable(), // when the user is registered to Lifthus

--- a/services/lifthus-auth/ent/session.go
+++ b/services/lifthus-auth/ent/session.go
@@ -19,7 +19,7 @@ type Session struct {
 	// ID of the ent.
 	ID uuid.UUID `json:"sid,omitempty"`
 	// UID holds the value of the "uid" field.
-	UID *uuid.UUID `json:"uid,omitempty"`
+	UID *uint64 `json:"uid,omitempty"`
 	// ConnectedAt holds the value of the "connected_at" field.
 	ConnectedAt time.Time `json:"connected_at,omitempty"`
 	// SignedAt holds the value of the "signed_at" field.
@@ -58,10 +58,10 @@ func (*Session) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case session.FieldUID:
-			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case session.FieldUsed:
 			values[i] = new(sql.NullBool)
+		case session.FieldUID:
+			values[i] = new(sql.NullInt64)
 		case session.FieldConnectedAt, session.FieldSignedAt:
 			values[i] = new(sql.NullTime)
 		case session.FieldID:
@@ -88,11 +88,11 @@ func (s *Session) assignValues(columns []string, values []any) error {
 				s.ID = *value
 			}
 		case session.FieldUID:
-			if value, ok := values[i].(*sql.NullScanner); !ok {
+			if value, ok := values[i].(*sql.NullInt64); !ok {
 				return fmt.Errorf("unexpected type %T for field uid", values[i])
 			} else if value.Valid {
-				s.UID = new(uuid.UUID)
-				*s.UID = *value.S.(*uuid.UUID)
+				s.UID = new(uint64)
+				*s.UID = uint64(value.Int64)
 			}
 		case session.FieldConnectedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {

--- a/services/lifthus-auth/ent/session/where.go
+++ b/services/lifthus-auth/ent/session/where.go
@@ -57,7 +57,7 @@ func IDLTE(id uuid.UUID) predicate.Session {
 }
 
 // UID applies equality check predicate on the "uid" field. It's identical to UIDEQ.
-func UID(v uuid.UUID) predicate.Session {
+func UID(v uint64) predicate.Session {
 	return predicate.Session(sql.FieldEQ(FieldUID, v))
 }
 
@@ -77,22 +77,22 @@ func Used(v bool) predicate.Session {
 }
 
 // UIDEQ applies the EQ predicate on the "uid" field.
-func UIDEQ(v uuid.UUID) predicate.Session {
+func UIDEQ(v uint64) predicate.Session {
 	return predicate.Session(sql.FieldEQ(FieldUID, v))
 }
 
 // UIDNEQ applies the NEQ predicate on the "uid" field.
-func UIDNEQ(v uuid.UUID) predicate.Session {
+func UIDNEQ(v uint64) predicate.Session {
 	return predicate.Session(sql.FieldNEQ(FieldUID, v))
 }
 
 // UIDIn applies the In predicate on the "uid" field.
-func UIDIn(vs ...uuid.UUID) predicate.Session {
+func UIDIn(vs ...uint64) predicate.Session {
 	return predicate.Session(sql.FieldIn(FieldUID, vs...))
 }
 
 // UIDNotIn applies the NotIn predicate on the "uid" field.
-func UIDNotIn(vs ...uuid.UUID) predicate.Session {
+func UIDNotIn(vs ...uint64) predicate.Session {
 	return predicate.Session(sql.FieldNotIn(FieldUID, vs...))
 }
 

--- a/services/lifthus-auth/ent/session_create.go
+++ b/services/lifthus-auth/ent/session_create.go
@@ -23,13 +23,13 @@ type SessionCreate struct {
 }
 
 // SetUID sets the "uid" field.
-func (sc *SessionCreate) SetUID(u uuid.UUID) *SessionCreate {
+func (sc *SessionCreate) SetUID(u uint64) *SessionCreate {
 	sc.mutation.SetUID(u)
 	return sc
 }
 
 // SetNillableUID sets the "uid" field if the given value is not nil.
-func (sc *SessionCreate) SetNillableUID(u *uuid.UUID) *SessionCreate {
+func (sc *SessionCreate) SetNillableUID(u *uint64) *SessionCreate {
 	if u != nil {
 		sc.SetUID(*u)
 	}
@@ -93,13 +93,13 @@ func (sc *SessionCreate) SetNillableID(u *uuid.UUID) *SessionCreate {
 }
 
 // SetUserID sets the "user" edge to the User entity by ID.
-func (sc *SessionCreate) SetUserID(id uuid.UUID) *SessionCreate {
+func (sc *SessionCreate) SetUserID(id uint64) *SessionCreate {
 	sc.mutation.SetUserID(id)
 	return sc
 }
 
 // SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (sc *SessionCreate) SetNillableUserID(id *uuid.UUID) *SessionCreate {
+func (sc *SessionCreate) SetNillableUserID(id *uint64) *SessionCreate {
 	if id != nil {
 		sc = sc.SetUserID(*id)
 	}
@@ -224,7 +224,7 @@ func (sc *SessionCreate) createSpec() (*Session, *sqlgraph.CreateSpec) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeUUID,
+					Type:   field.TypeUint64,
 					Column: user.FieldID,
 				},
 			},

--- a/services/lifthus-auth/ent/session_query.go
+++ b/services/lifthus-auth/ent/session_query.go
@@ -298,7 +298,7 @@ func (sq *SessionQuery) WithUser(opts ...func(*UserQuery)) *SessionQuery {
 // Example:
 //
 //	var v []struct {
-//		UID uuid.UUID `json:"uid,omitempty"`
+//		UID uint64 `json:"uid,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -321,7 +321,7 @@ func (sq *SessionQuery) GroupBy(field string, fields ...string) *SessionGroupBy 
 // Example:
 //
 //	var v []struct {
-//		UID uuid.UUID `json:"uid,omitempty"`
+//		UID uint64 `json:"uid,omitempty"`
 //	}
 //
 //	client.Session.Query().
@@ -402,8 +402,8 @@ func (sq *SessionQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Sess
 }
 
 func (sq *SessionQuery) loadUser(ctx context.Context, query *UserQuery, nodes []*Session, init func(*Session), assign func(*Session, *User)) error {
-	ids := make([]uuid.UUID, 0, len(nodes))
-	nodeids := make(map[uuid.UUID][]*Session)
+	ids := make([]uint64, 0, len(nodes))
+	nodeids := make(map[uint64][]*Session)
 	for i := range nodes {
 		if nodes[i].UID == nil {
 			continue

--- a/services/lifthus-auth/ent/session_update.go
+++ b/services/lifthus-auth/ent/session_update.go
@@ -14,7 +14,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/google/uuid"
 )
 
 // SessionUpdate is the builder for updating Session entities.
@@ -31,13 +30,13 @@ func (su *SessionUpdate) Where(ps ...predicate.Session) *SessionUpdate {
 }
 
 // SetUID sets the "uid" field.
-func (su *SessionUpdate) SetUID(u uuid.UUID) *SessionUpdate {
+func (su *SessionUpdate) SetUID(u uint64) *SessionUpdate {
 	su.mutation.SetUID(u)
 	return su
 }
 
 // SetNillableUID sets the "uid" field if the given value is not nil.
-func (su *SessionUpdate) SetNillableUID(u *uuid.UUID) *SessionUpdate {
+func (su *SessionUpdate) SetNillableUID(u *uint64) *SessionUpdate {
 	if u != nil {
 		su.SetUID(*u)
 	}
@@ -91,13 +90,13 @@ func (su *SessionUpdate) SetNillableUsed(b *bool) *SessionUpdate {
 }
 
 // SetUserID sets the "user" edge to the User entity by ID.
-func (su *SessionUpdate) SetUserID(id uuid.UUID) *SessionUpdate {
+func (su *SessionUpdate) SetUserID(id uint64) *SessionUpdate {
 	su.mutation.SetUserID(id)
 	return su
 }
 
 // SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (su *SessionUpdate) SetNillableUserID(id *uuid.UUID) *SessionUpdate {
+func (su *SessionUpdate) SetNillableUserID(id *uint64) *SessionUpdate {
 	if id != nil {
 		su = su.SetUserID(*id)
 	}
@@ -186,7 +185,7 @@ func (su *SessionUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeUUID,
+					Type:   field.TypeUint64,
 					Column: user.FieldID,
 				},
 			},
@@ -202,7 +201,7 @@ func (su *SessionUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeUUID,
+					Type:   field.TypeUint64,
 					Column: user.FieldID,
 				},
 			},
@@ -233,13 +232,13 @@ type SessionUpdateOne struct {
 }
 
 // SetUID sets the "uid" field.
-func (suo *SessionUpdateOne) SetUID(u uuid.UUID) *SessionUpdateOne {
+func (suo *SessionUpdateOne) SetUID(u uint64) *SessionUpdateOne {
 	suo.mutation.SetUID(u)
 	return suo
 }
 
 // SetNillableUID sets the "uid" field if the given value is not nil.
-func (suo *SessionUpdateOne) SetNillableUID(u *uuid.UUID) *SessionUpdateOne {
+func (suo *SessionUpdateOne) SetNillableUID(u *uint64) *SessionUpdateOne {
 	if u != nil {
 		suo.SetUID(*u)
 	}
@@ -293,13 +292,13 @@ func (suo *SessionUpdateOne) SetNillableUsed(b *bool) *SessionUpdateOne {
 }
 
 // SetUserID sets the "user" edge to the User entity by ID.
-func (suo *SessionUpdateOne) SetUserID(id uuid.UUID) *SessionUpdateOne {
+func (suo *SessionUpdateOne) SetUserID(id uint64) *SessionUpdateOne {
 	suo.mutation.SetUserID(id)
 	return suo
 }
 
 // SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (suo *SessionUpdateOne) SetNillableUserID(id *uuid.UUID) *SessionUpdateOne {
+func (suo *SessionUpdateOne) SetNillableUserID(id *uint64) *SessionUpdateOne {
 	if id != nil {
 		suo = suo.SetUserID(*id)
 	}
@@ -418,7 +417,7 @@ func (suo *SessionUpdateOne) sqlSave(ctx context.Context) (_node *Session, err e
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeUUID,
+					Type:   field.TypeUint64,
 					Column: user.FieldID,
 				},
 			},
@@ -434,7 +433,7 @@ func (suo *SessionUpdateOne) sqlSave(ctx context.Context) (_node *Session, err e
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeUUID,
+					Type:   field.TypeUint64,
 					Column: user.FieldID,
 				},
 			},

--- a/services/lifthus-auth/ent/user.go
+++ b/services/lifthus-auth/ent/user.go
@@ -9,14 +9,13 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
-	"github.com/google/uuid"
 )
 
 // User is the model entity for the User schema.
 type User struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID uuid.UUID `json:"uid,omitempty"`
+	ID uint64 `json:"uid,omitempty"`
 	// Registered holds the value of the "registered" field.
 	Registered bool `json:"registered,omitempty"`
 	// RegisteredAt holds the value of the "registered_at" field.
@@ -71,12 +70,12 @@ func (*User) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case user.FieldRegistered, user.FieldEmailVerified:
 			values[i] = new(sql.NullBool)
+		case user.FieldID:
+			values[i] = new(sql.NullInt64)
 		case user.FieldUsername, user.FieldEmail, user.FieldName, user.FieldGivenName, user.FieldFamilyName, user.FieldProfilePictureURL:
 			values[i] = new(sql.NullString)
 		case user.FieldRegisteredAt, user.FieldBirthdate, user.FieldCreatedAt, user.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
-		case user.FieldID:
-			values[i] = new(uuid.UUID)
 		default:
 			return nil, fmt.Errorf("unexpected column %q for type User", columns[i])
 		}
@@ -93,11 +92,11 @@ func (u *User) assignValues(columns []string, values []any) error {
 	for i := range columns {
 		switch columns[i] {
 		case user.FieldID:
-			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field id", values[i])
-			} else if value != nil {
-				u.ID = *value
+			value, ok := values[i].(*sql.NullInt64)
+			if !ok {
+				return fmt.Errorf("unexpected type %T for field id", value)
 			}
+			u.ID = uint64(value.Int64)
 		case user.FieldRegistered:
 			if value, ok := values[i].(*sql.NullBool); !ok {
 				return fmt.Errorf("unexpected type %T for field registered", values[i])

--- a/services/lifthus-auth/ent/user/user.go
+++ b/services/lifthus-auth/ent/user/user.go
@@ -4,8 +4,6 @@ package user
 
 import (
 	"time"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -86,6 +84,4 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
-	// DefaultID holds the default value on creation for the "id" field.
-	DefaultID func() uuid.UUID
 )

--- a/services/lifthus-auth/ent/user/where.go
+++ b/services/lifthus-auth/ent/user/where.go
@@ -8,51 +8,50 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"github.com/google/uuid"
 )
 
 // ID filters vertices based on their ID field.
-func ID(id uuid.UUID) predicate.User {
+func ID(id uint64) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldID, id))
 }
 
 // IDEQ applies the EQ predicate on the ID field.
-func IDEQ(id uuid.UUID) predicate.User {
+func IDEQ(id uint64) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldID, id))
 }
 
 // IDNEQ applies the NEQ predicate on the ID field.
-func IDNEQ(id uuid.UUID) predicate.User {
+func IDNEQ(id uint64) predicate.User {
 	return predicate.User(sql.FieldNEQ(FieldID, id))
 }
 
 // IDIn applies the In predicate on the ID field.
-func IDIn(ids ...uuid.UUID) predicate.User {
+func IDIn(ids ...uint64) predicate.User {
 	return predicate.User(sql.FieldIn(FieldID, ids...))
 }
 
 // IDNotIn applies the NotIn predicate on the ID field.
-func IDNotIn(ids ...uuid.UUID) predicate.User {
+func IDNotIn(ids ...uint64) predicate.User {
 	return predicate.User(sql.FieldNotIn(FieldID, ids...))
 }
 
 // IDGT applies the GT predicate on the ID field.
-func IDGT(id uuid.UUID) predicate.User {
+func IDGT(id uint64) predicate.User {
 	return predicate.User(sql.FieldGT(FieldID, id))
 }
 
 // IDGTE applies the GTE predicate on the ID field.
-func IDGTE(id uuid.UUID) predicate.User {
+func IDGTE(id uint64) predicate.User {
 	return predicate.User(sql.FieldGTE(FieldID, id))
 }
 
 // IDLT applies the LT predicate on the ID field.
-func IDLT(id uuid.UUID) predicate.User {
+func IDLT(id uint64) predicate.User {
 	return predicate.User(sql.FieldLT(FieldID, id))
 }
 
 // IDLTE applies the LTE predicate on the ID field.
-func IDLTE(id uuid.UUID) predicate.User {
+func IDLTE(id uint64) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldID, id))
 }
 

--- a/services/lifthus-auth/ent/user_delete.go
+++ b/services/lifthus-auth/ent/user_delete.go
@@ -40,7 +40,7 @@ func (ud *UserDelete) ExecX(ctx context.Context) int {
 }
 
 func (ud *UserDelete) sqlExec(ctx context.Context) (int, error) {
-	_spec := sqlgraph.NewDeleteSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
+	_spec := sqlgraph.NewDeleteSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUint64))
 	if ps := ud.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {

--- a/services/lifthus-auth/ent/user_query.go
+++ b/services/lifthus-auth/ent/user_query.go
@@ -14,7 +14,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/google/uuid"
 )
 
 // UserQuery is the builder for querying User entities.
@@ -107,8 +106,8 @@ func (uq *UserQuery) FirstX(ctx context.Context) *User {
 
 // FirstID returns the first User ID from the query.
 // Returns a *NotFoundError when no User ID was found.
-func (uq *UserQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
-	var ids []uuid.UUID
+func (uq *UserQuery) FirstID(ctx context.Context) (id uint64, err error) {
+	var ids []uint64
 	if ids, err = uq.Limit(1).IDs(setContextOp(ctx, uq.ctx, "FirstID")); err != nil {
 		return
 	}
@@ -120,7 +119,7 @@ func (uq *UserQuery) FirstID(ctx context.Context) (id uuid.UUID, err error) {
 }
 
 // FirstIDX is like FirstID, but panics if an error occurs.
-func (uq *UserQuery) FirstIDX(ctx context.Context) uuid.UUID {
+func (uq *UserQuery) FirstIDX(ctx context.Context) uint64 {
 	id, err := uq.FirstID(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
@@ -158,8 +157,8 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 // OnlyID is like Only, but returns the only User ID in the query.
 // Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
-func (uq *UserQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
-	var ids []uuid.UUID
+func (uq *UserQuery) OnlyID(ctx context.Context) (id uint64, err error) {
+	var ids []uint64
 	if ids, err = uq.Limit(2).IDs(setContextOp(ctx, uq.ctx, "OnlyID")); err != nil {
 		return
 	}
@@ -175,7 +174,7 @@ func (uq *UserQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 }
 
 // OnlyIDX is like OnlyID, but panics if an error occurs.
-func (uq *UserQuery) OnlyIDX(ctx context.Context) uuid.UUID {
+func (uq *UserQuery) OnlyIDX(ctx context.Context) uint64 {
 	id, err := uq.OnlyID(ctx)
 	if err != nil {
 		panic(err)
@@ -203,7 +202,7 @@ func (uq *UserQuery) AllX(ctx context.Context) []*User {
 }
 
 // IDs executes the query and returns a list of User IDs.
-func (uq *UserQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error) {
+func (uq *UserQuery) IDs(ctx context.Context) (ids []uint64, err error) {
 	if uq.ctx.Unique == nil && uq.path != nil {
 		uq.Unique(true)
 	}
@@ -215,7 +214,7 @@ func (uq *UserQuery) IDs(ctx context.Context) (ids []uuid.UUID, err error) {
 }
 
 // IDsX is like IDs, but panics if an error occurs.
-func (uq *UserQuery) IDsX(ctx context.Context) []uuid.UUID {
+func (uq *UserQuery) IDsX(ctx context.Context) []uint64 {
 	ids, err := uq.IDs(ctx)
 	if err != nil {
 		panic(err)
@@ -405,7 +404,7 @@ func (uq *UserQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*User, e
 
 func (uq *UserQuery) loadSessions(ctx context.Context, query *SessionQuery, nodes []*User, init func(*User), assign func(*User, *Session)) error {
 	fks := make([]driver.Value, 0, len(nodes))
-	nodeids := make(map[uuid.UUID]*User)
+	nodeids := make(map[uint64]*User)
 	for i := range nodes {
 		fks = append(fks, nodes[i].ID)
 		nodeids[nodes[i].ID] = nodes[i]
@@ -444,7 +443,7 @@ func (uq *UserQuery) sqlCount(ctx context.Context) (int, error) {
 }
 
 func (uq *UserQuery) querySpec() *sqlgraph.QuerySpec {
-	_spec := sqlgraph.NewQuerySpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
+	_spec := sqlgraph.NewQuerySpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUint64))
 	_spec.From = uq.sql
 	if unique := uq.ctx.Unique; unique != nil {
 		_spec.Unique = *unique

--- a/services/lifthus-auth/ent/user_update.go
+++ b/services/lifthus-auth/ent/user_update.go
@@ -252,7 +252,7 @@ func (uu *UserUpdate) defaults() {
 }
 
 func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
+	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUint64))
 	if ps := uu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
@@ -617,7 +617,7 @@ func (uuo *UserUpdateOne) defaults() {
 }
 
 func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) {
-	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUUID))
+	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeUint64))
 	id, ok := uuo.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "User.id" for update`)}

--- a/services/lifthus-auth/go.sum
+++ b/services/lifthus-auth/go.sum
@@ -347,6 +347,7 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mediocregopher/radix/v3 v3.8.0/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.18/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
@@ -379,6 +380,7 @@ github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
@@ -433,9 +435,11 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=

--- a/services/lifthus-auth/service/session/session.go
+++ b/services/lifthus-auth/service/session/session.go
@@ -51,19 +51,33 @@ func RevokeSession(ctx context.Context, client *ent.Client, sid string) error {
 	return nil
 }
 
-func SignSession(ctx context.Context, client *ent.Client, sid string, uid string) error {
+func SignSession(ctx context.Context, client *ent.Client, sid string, uid uint64) error {
 	sid_uuid, err := uuid.Parse(sid)
-	uid_uuid, err1 := uuid.Parse(uid)
-	if err != nil || err1 != nil {
-		return fmt.Errorf("!!parsing uuid failed: %w, %w", err, err1)
+	if err != nil {
+		return fmt.Errorf("!!parsing uuid failed: %w", err)
 	}
 	// update the session with uid
-	_, err = client.Session.UpdateOneID(sid_uuid).SetUID(uid_uuid).SetUsed(false).Save(ctx)
+	_, err = client.Session.UpdateOneID(sid_uuid).SetUID(uid).SetUsed(false).Save(ctx)
 	if err != nil {
 		return fmt.Errorf("!!updating session with uid failed: %w", err)
 	}
 	return nil
 }
+
+// UUID version
+// func SignSession(ctx context.Context, client *ent.Client, sid string, uid string) error {
+// 	sid_uuid, err := uuid.Parse(sid)
+// 	uid_uuid, err1 := uuid.Parse(uid)
+// 	if err != nil || err1 != nil {
+// 		return fmt.Errorf("!!parsing uuid failed: %w, %w", err, err1)
+// 	}
+// 	// update the session with uid
+// 	_, err = client.Session.UpdateOneID(sid_uuid).SetUID(uid_uuid).SetUsed(false).Save(ctx)
+// 	if err != nil {
+// 		return fmt.Errorf("!!updating session with uid failed: %w", err)
+// 	}
+// 	return nil
+// }
 
 // ValidateSession validates the session and updates the db.
 // cases:


### PR DESCRIPTION
#### ⚒️ What does this new feature do?
now user primary key is Uint64. Instead of UUID.

#### 😮 Why is this change necessary?
Uint64 takes half memory, half storage and is much faster.

#### ⚠️ What side effects does this change have?
Maybe the capability of 64-bit number will run out 9999999999999 years later.

#### ✅ Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ✅] Build successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Lifthus's policy.
